### PR TITLE
Update to lts-22.22 (build fix from upstream crypton package renames)

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -30,10 +30,10 @@ dependencies:
 - network
 - tls
 - data-default-class
-- x509-store
-- x509-system
+- crypton
+- crypton-x509-store
+- crypton-x509-system
 - uuid-types
-- crypto-random
 - template-haskell
 
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -22,7 +22,8 @@
 #resolver: lts-16.31  # ghc-8.8.4
 #resolver: lts-18.21  # ghc-8.10.7
 #resolver: lts-19.33  # ghc-9.0.2
-resolver: lts-20.16  # ghc-9.2.7
+#resolver: lts-20.16  # ghc-9.2.7
+resolver: lts-22.22  # ghc-9.6.5
 #resolver: nightly-2023-03-31 # ghc-9.4.4
 
 

--- a/stack_lts-6.35.yaml
+++ b/stack_lts-6.35.yaml
@@ -1,8 +1,0 @@
-resolver: lts-6.35
-
-packages:
-- .
-
-extra-deps:
-- binary-0.8.7.0
-


### PR DESCRIPTION
- x509 packages renamed to have crypton prefix.
- crypto-random is deprecated in favor of cryptonite, which was in turn renamed to crypton.
- Remove stack_lts-6.35.yaml .  It's a very old LTS, and this dependency change almost certainly breaks it.

Fixes #2